### PR TITLE
export empty functions on set and map

### DIFF
--- a/src/Data/Map/Word8.hs
+++ b/src/Data/Map/Word8.hs
@@ -8,6 +8,7 @@
 module Data.Map.Word8
   ( Map
   , lookup
+  , empty
   , singleton
   , union
   , unionWith

--- a/src/Data/Set/Word8.hs
+++ b/src/Data/Set/Word8.hs
@@ -4,6 +4,7 @@
 module Data.Set.Word8
   ( Set
   , member
+  , empty
   , singleton
   , union
   ) where
@@ -20,6 +21,9 @@ import qualified Data.Primitive as PM
 
 -- | A map whose keys are 8-bit words.
 newtype Set = Set Word256
+
+empty :: Set
+empty = Set 0
 
 singleton :: Word8 -> Set
 singleton !k = Set (bit (fromIntegral @Word8 @Int k))


### PR DESCRIPTION
I noticed the `Monoid` instance for `Map a` requires `Semigroup a`, so exporting `empty` separately is more general. Threw in `Set.empty` while I was at it.